### PR TITLE
Add MSX game download from tsx.eslamejor.com (MSXDB)

### DIFF
--- a/src/HMI.h
+++ b/src/HMI.h
@@ -791,7 +791,7 @@ private:
                   logln("Registering files in path: " + path);   
               #endif
       
-              bool zxdb_search = (FILE_LAST_DIR.indexOf("/ONLINE/") != -1 || FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1) ? true : false;
+              bool zxdb_search = (FILE_LAST_DIR.indexOf("/ONLINE/") != -1 || FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1 || FILE_LAST_DIR.indexOf("/ONLINE_MSX/") != -1) ? true : false;
               if (zxdb_search)
               {
                   // Si la ruta es ONLINE, no intentamos cargar un _files.lst previo
@@ -1125,7 +1125,7 @@ private:
               {
                 // Si el archivo no existe o se fuerza el rescan, lo generamos
                 // Si el directorio no es ONLINE, no forzamos el rescan aunque se haya pedido, para evitar destruirlo ya que es virtual
-                if (FILE_LAST_DIR.indexOf("ONLINE") == -1 && FILE_LAST_DIR.indexOf("ONLINE_CPC") == -1) force_rescan = false;
+                if (FILE_LAST_DIR.indexOf("ONLINE") == -1 && FILE_LAST_DIR.indexOf("ONLINE_CPC") == -1 && FILE_LAST_DIR.indexOf("ONLINE_MSX") == -1) force_rescan = false;
 
                 registerFiles(FILE_LAST_DIR, output_file, output_file_inf, search_pattern, force_rescan);
               }
@@ -1430,7 +1430,7 @@ private:
               {
                 color = DSC_FILE_COLOR;  // Negro - Indica que es un fichero DSC
               }
-              else if (type == ".TAP" || type == ".TZX" || type == ".TSX" || type == ".CDT" || type == ".PZX" || type == ".WAV" || type == ".MP3" || type == ".FLAC" || type == ".RADIO" || type == ".ZXDB" || type == ".CPCDB")
+              else if (type == ".TAP" || type == ".TZX" || type == ".TSX" || type == ".CDT" || type == ".PZX" || type == ".WAV" || type == ".MP3" || type == ".FLAC" || type == ".RADIO" || type == ".ZXDB" || type == ".CPCDB" || type == ".MSXDB")
               {
                   //Ficheros
                   if (SD_MMC.exists("/fav/" + szName))
@@ -1972,7 +1972,7 @@ private:
         else if (strCmd.indexOf("RFSH") != -1) 
         {
             // No se hace rescan en los subdirectorios de /ONLINE porque destruye el catalogo
-            if (!FB_READING_FILES && !(FILE_LAST_DIR.indexOf("/ONLINE/") != -1) && !(FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1))
+            if (!FB_READING_FILES && !(FILE_LAST_DIR.indexOf("/ONLINE/") != -1) && !(FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1) && !(FILE_LAST_DIR.indexOf("/ONLINE_MSX/") != -1))
             {
               reloadDir();
               REGENERATE_IDX = true;
@@ -2381,7 +2381,7 @@ private:
 
               String recDirTmp = FILE_LAST_DIR;
               recDirTmp.toUpperCase();
-              if (recDirTmp == "/FAV/" || recDirTmp == "/REC/" || recDirTmp == "/WAV" || recDirTmp == "/DOWNLOAD" || recDirTmp == "/DOWNLOAD_CPC" || recDirTmp == "/ONLINE" || recDirTmp == "/ONLINE_CPC")
+              if (recDirTmp == "/FAV/" || recDirTmp == "/REC/" || recDirTmp == "/WAV" || recDirTmp == "/DOWNLOAD" || recDirTmp == "/DOWNLOAD_CPC" || recDirTmp == "/DOWNLOAD_MSX" || recDirTmp == "/ONLINE" || recDirTmp == "/ONLINE_CPC" || recDirTmp == "/ONLINE_MSX")
               {
                 getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
               }
@@ -2624,6 +2624,24 @@ private:
                   logln("Title of file to download: " + tittle);
                   logln("Starting download from CPCDB ...");
                   downloadFromCPCDB(cdtFileName, tittle);
+                }
+
+              }
+              else if (FILE_LOAD.indexOf(".msxdb") != -1)
+              {
+                // Es un fichero virtual MSXDB. Hay que descargarlo primero.
+                logln("File is a virtual MSXDB file. Downloading ...");
+                // Cogemos el nombre del fichero sin .msxdb
+                String tittle = FILE_LOAD.substring(0, FILE_LOAD.length() - 6);
+                // Buscamos en _files.lst la ruta real del CAS (e.g. "CLOAD/Game (EU).cas")
+                String casFileName = getIdOfFileInLst(FILE_LAST_DIR + "/_files.lst", FILES_BUFF[FILE_IDX_SELECTED+1].path);
+
+                if (casFileName != "")
+                {
+                  logln("CAS file to download: " + casFileName);
+                  logln("Title of file to download: " + tittle);
+                  logln("Starting download from MSXDB ...");
+                  downloadFromMSXDB(casFileName, tittle);
                 }
 
               }
@@ -3083,6 +3101,23 @@ private:
           }
 
           jumpToDir("/ONLINE_CPC");
+          getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
+          refreshFiles();
+        }
+        else if (strCmd.indexOf("CMSX") != -1)
+        {
+          // Salta al directorio de MSXDB online (MSX).
+          logln("Jumping to MSXDB dir.");
+          SOURCE_FILE_TO_MANAGE = "_files.lst";
+          SOURCE_FILE_INF_TO_MANAGE = "_files.inf";
+
+          LST_FILE_IS_OPEN = false;
+          if (fFileLST)
+          {
+            fFileLST.close();
+          }
+
+          jumpToDir("/ONLINE_MSX");
           getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
           refreshFiles();
         }
@@ -3961,6 +3996,15 @@ private:
           char str = (char)buff[5];
           logln("Update CPCDB with letter: " + String(str));
           updateCPCDB(String(str));
+        }
+        else if (strCmd.indexOf("MSXD=") != -1)
+        {
+          // Actualizar catálogo MSXDB para una letra
+          uint8_t buff[8];
+          strCmd.getBytes(buff, 7);
+          char str = (char)buff[5];
+          logln("Update MSXDB with letter: " + String(str));
+          updateMSXDB(String(str));
         }
         else if (strCmd.indexOf("PDEBUG") != -1)
         {

--- a/src/HMI.h
+++ b/src/HMI.h
@@ -791,7 +791,7 @@ private:
                   logln("Registering files in path: " + path);   
               #endif
       
-              bool zxdb_search = FILE_LAST_DIR.indexOf("/ONLINE/") != -1 ? true : false;
+              bool zxdb_search = (FILE_LAST_DIR.indexOf("/ONLINE/") != -1 || FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1) ? true : false;
               if (zxdb_search)
               {
                   // Si la ruta es ONLINE, no intentamos cargar un _files.lst previo
@@ -1125,7 +1125,7 @@ private:
               {
                 // Si el archivo no existe o se fuerza el rescan, lo generamos
                 // Si el directorio no es ONLINE, no forzamos el rescan aunque se haya pedido, para evitar destruirlo ya que es virtual
-                if (FILE_LAST_DIR.indexOf("ONLINE") == -1) force_rescan = false;
+                if (FILE_LAST_DIR.indexOf("ONLINE") == -1 && FILE_LAST_DIR.indexOf("ONLINE_CPC") == -1) force_rescan = false;
 
                 registerFiles(FILE_LAST_DIR, output_file, output_file_inf, search_pattern, force_rescan);
               }
@@ -1430,7 +1430,7 @@ private:
               {
                 color = DSC_FILE_COLOR;  // Negro - Indica que es un fichero DSC
               }
-              else if (type == ".TAP" || type == ".TZX" || type == ".TSX" || type == ".CDT" || type == ".PZX" || type == ".WAV" || type == ".MP3" || type == ".FLAC" || type == ".RADIO" || type == ".ZXDB")
+              else if (type == ".TAP" || type == ".TZX" || type == ".TSX" || type == ".CDT" || type == ".PZX" || type == ".WAV" || type == ".MP3" || type == ".FLAC" || type == ".RADIO" || type == ".ZXDB" || type == ".CPCDB")
               {
                   //Ficheros
                   if (SD_MMC.exists("/fav/" + szName))
@@ -1972,7 +1972,7 @@ private:
         else if (strCmd.indexOf("RFSH") != -1) 
         {
             // No se hace rescan en los subdirectorios de /ONLINE porque destruye el catalogo
-            if (!FB_READING_FILES && !(FILE_LAST_DIR.indexOf("/ONLINE/") != -1))
+            if (!FB_READING_FILES && !(FILE_LAST_DIR.indexOf("/ONLINE/") != -1) && !(FILE_LAST_DIR.indexOf("/ONLINE_CPC/") != -1))
             {
               reloadDir();
               REGENERATE_IDX = true;
@@ -2381,7 +2381,7 @@ private:
 
               String recDirTmp = FILE_LAST_DIR;
               recDirTmp.toUpperCase();
-              if (recDirTmp == "/FAV/" || recDirTmp == "/REC/" || recDirTmp == "/WAV" || recDirTmp == "/DOWNLOAD" || recDirTmp == "/ONLINE")
+              if (recDirTmp == "/FAV/" || recDirTmp == "/REC/" || recDirTmp == "/WAV" || recDirTmp == "/DOWNLOAD" || recDirTmp == "/DOWNLOAD_CPC" || recDirTmp == "/ONLINE" || recDirTmp == "/ONLINE_CPC")
               {
                 getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
               }
@@ -2593,8 +2593,8 @@ private:
 
               if (FILE_LOAD.indexOf(".zxdb") != -1)
               {
-                // Es un fichero virtual. Hay que descargarlo primero.
-                logln("File is a virtual file. Downloading ...");
+                // Es un fichero virtual ZXDB. Hay que descargarlo primero.
+                logln("File is a virtual ZXDB file. Downloading ...");
                 // Cogemos el nombre del fichero sin .zxdb
                 String tittle = FILE_LOAD.substring(0, FILE_LOAD.length() - 5);
                 // Buscamos en _files.lst el ID que le corresponde a ese fichero para descargarlo
@@ -2606,6 +2606,24 @@ private:
                   logln("Title of file to download: " + tittle);
                   logln("Starting download from ZXDB ...");
                   downloadFromZXDB(idFile, tittle);
+                }
+
+              }
+              else if (FILE_LOAD.indexOf(".cpcdb") != -1)
+              {
+                // Es un fichero virtual CPCDB. Hay que descargarlo primero.
+                logln("File is a virtual CPCDB file. Downloading ...");
+                // Cogemos el nombre del fichero sin .cpcdb
+                String tittle = FILE_LOAD.substring(0, FILE_LOAD.length() - 6);
+                // Buscamos en _files.lst el nombre real del CDT
+                String cdtFileName = getIdOfFileInLst(FILE_LAST_DIR + "/_files.lst", FILES_BUFF[FILE_IDX_SELECTED+1].path);
+
+                if (cdtFileName != "")
+                {
+                  logln("CDT file to download: " + cdtFileName);
+                  logln("Title of file to download: " + tittle);
+                  logln("Starting download from CPCDB ...");
+                  downloadFromCPCDB(cdtFileName, tittle);
                 }
 
               }
@@ -3051,7 +3069,24 @@ private:
           getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
           refreshFiles();           
         }
-        else if (strCmd.indexOf("RADI") != -1) 
+        else if (strCmd.indexOf("CCPC") != -1)
+        {
+          // Salta al directorio de CPCDB online (Amstrad CPC).
+          logln("Jumping to CPCDB dir.");
+          SOURCE_FILE_TO_MANAGE = "_files.lst";
+          SOURCE_FILE_INF_TO_MANAGE = "_files.inf";
+
+          LST_FILE_IS_OPEN = false;
+          if (fFileLST)
+          {
+            fFileLST.close();
+          }
+
+          jumpToDir("/ONLINE_CPC");
+          getFilesFromSD(true,SOURCE_FILE_TO_MANAGE,SOURCE_FILE_INF_TO_MANAGE);
+          refreshFiles();
+        }
+        else if (strCmd.indexOf("RADI") != -1)
         {
           // Salta al directorio de RADIO internet.
           logln("Jumping to internet radio dir.");
@@ -3908,7 +3943,7 @@ private:
           
           findTheTextInFiles();
         }
-        else if (strCmd.indexOf("ZXDB=") != -1) 
+        else if (strCmd.indexOf("ZXDB=") != -1)
         {
           //Cogemos el valor
           uint8_t buff[8];
@@ -3917,7 +3952,16 @@ private:
           //
           logln("Update ZXDB with letter: " + String(str));
           updateZXDB(String(str));
-        }        
+        }
+        else if (strCmd.indexOf("CPCD=") != -1)
+        {
+          // Actualizar catálogo CPCDB para una letra
+          uint8_t buff[8];
+          strCmd.getBytes(buff, 7);
+          char str = (char)buff[5];
+          logln("Update CPCDB with letter: " + String(str));
+          updateCPCDB(String(str));
+        }
         else if (strCmd.indexOf("PDEBUG") != -1)
         {
             // Estamos en la pantalla DEBUG

--- a/src/globales.h
+++ b/src/globales.h
@@ -832,6 +832,7 @@ String SPOTIFY_CLIENT_SECRET = "";
 bool QUICK_BOOT = false;
 bool DOWNLOADING_ZXDB = false;
 bool DOWNLOADING_CPCDB = false;
+bool DOWNLOADING_MSXDB = false;
 bool BEEP = false;
 
 // Declaraciones de metodos
@@ -1805,7 +1806,6 @@ void downloadFromZXDB(String gameId, String title)
 
   String destDir = "/DOWNLOAD/" + safeTitle;
 
-  if (!SD_MMC.exists("/DOWNLOAD")) SD_MMC.mkdir("/DOWNLOAD");
   if (!SD_MMC.exists(destDir))
   {
     if (!SD_MMC.mkdir(destDir))
@@ -2274,7 +2274,6 @@ void downloadFromCPCDB(String fileName, String title)
 
   String destDir = "/DOWNLOAD_CPC/" + safeTitle;
 
-  if (!SD_MMC.exists("/DOWNLOAD_CPC")) SD_MMC.mkdir("/DOWNLOAD_CPC");
   if (!SD_MMC.exists(destDir))
   {
     if (!SD_MMC.mkdir(destDir))
@@ -2543,6 +2542,317 @@ void updateCPCDB(String letter = "0")
 
         logln("CPCDB: " + String(totalFiles) + " ficheros catalogados");
         myNex.writeStr("zxdb.message.txt", "Done: " + String(totalFiles) + " CPC games");
+        myNex.writeNum("zxdb.j0.val", 100);
+    }
+}
+
+// MSXDB - Descarga de juegos MSX desde tsx.eslamejor.com
+// API: /index_back.php?page=N&idx=LETRA (JSON, 50 por página)
+// Descarga: /tsx-files/{TOSEC.NAME}.tsx
+// =====================================================================
+
+const char* MSXDB_HOST = "tsx.eslamejor.com";
+
+// Descarga un fichero TSX individual desde tsx.eslamejor.com
+// fileName : nombre TOSEC completo (e.g. "Zakil Wood (1985)(Mr Micro)(ES)[!].tsx")
+// title    : nombre corto del juego para el subdirectorio en /DOWNLOAD_MSX/
+void downloadFromMSXDB(String fileName, String title)
+{
+  DOWNLOADING_MSXDB = true;
+  TYPE_FILE_LOAD = "MSXDB";
+
+  LAST_MESSAGE = "Downloading: " + title;
+  myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+
+  if (!WIFI_CONNECTED || !WIFI_ENABLE)
+  {
+    logln("WiFi no disponible para descarga MSXDB");
+    myNex.writeStr("tape.g0.txt", "No WiFi");
+    DOWNLOADING_MSXDB = false;
+    return;
+  }
+
+  // Sanitizar el título para nombre de directorio FAT32
+  String safeTitle = title;
+  safeTitle.replace("/",  "-");
+  safeTitle.replace("\\", "-");
+  safeTitle.replace(":",  "-");
+  safeTitle.replace("*",  "-");
+  safeTitle.replace("?",  "-");
+  safeTitle.replace("\"", "-");
+  safeTitle.replace("<",  "-");
+  safeTitle.replace(">",  "-");
+  safeTitle.replace("|",  "-");
+
+  String destDir = "/DOWNLOAD_MSX/" + safeTitle;
+
+  if (!SD_MMC.exists(destDir))
+  {
+    if (!SD_MMC.mkdir(destDir))
+    {
+      logln("Error al crear directorio: " + destDir);
+      myNex.writeStr("tape.g0.txt", "Error creating dir");
+      DOWNLOADING_MSXDB = false;
+      return;
+    }
+  }
+
+  // Construir URL de descarga: /tsx-files/{fileName}
+  String encodedFileName = fileName;
+  encodedFileName.replace(" ", "%20");
+  encodedFileName.replace("(", "%28");
+  encodedFileName.replace(")", "%29");
+  encodedFileName.replace("'", "%27");
+  encodedFileName.replace("&", "%26");
+  encodedFileName.replace(",", "%2C");
+  encodedFileName.replace("[", "%5B");
+  encodedFileName.replace("]", "%5D");
+
+  String downloadUrl = "https://" + String(MSXDB_HOST) + "/tsx-files/" + encodedFileName;
+
+  logln("Descargando TSX: " + downloadUrl);
+  myNex.writeStr("tape.g0.txt", "Downloading: " + title);
+
+  String localPath = destDir + "/" + fileName;
+
+  {
+    WiFiClientSecure secureClient;
+    secureClient.setInsecure();
+
+    HTTPClient http;
+    http.begin(secureClient, downloadUrl);
+    http.setTimeout(60000);
+    http.setConnectTimeout(30000);
+    http.addHeader("User-Agent", "PowaDCR/" + String(VERSION));
+    http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+
+    int httpCode = http.GET();
+    if (httpCode == HTTP_CODE_OK)
+    {
+      File file = SD_MMC.open(localPath.c_str(), FILE_WRITE);
+      if (file)
+      {
+        int written = http.writeToStream(&file);
+        file.flush();
+        file.close();
+        logln("Descargados " + String(written) + " bytes -> " + localPath);
+        LAST_MESSAGE = "Download done. See /DOWNLOAD_MSX";
+        myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+      }
+      else
+      {
+        logln("No se pudo crear fichero: " + localPath);
+        LAST_MESSAGE = "Error creating file";
+        myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+      }
+    }
+    else
+    {
+      logln("Error HTTP " + String(httpCode) + " descargando: " + downloadUrl);
+      LAST_MESSAGE = "Download error " + String(httpCode);
+      myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+    }
+    http.end();
+  }
+
+  DOWNLOADING_MSXDB = false;
+}
+
+// Consulta la API de tsx.eslamejor.com para generar
+// el catálogo /ONLINE_MSX/{letra}/_files.lst
+// La API devuelve JSON paginado: /index_back.php?page=N&idx=LETRA
+void updateMSXDB(String letter = "0")
+{
+    String searchChain = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ0";
+
+    if (WIFI_CONNECTED && WIFI_ENABLE)
+    {
+        myNex.writeNum("zxdb.j0.val", 0);
+
+        if (letter != "0")
+        {
+          searchChain = letter;
+          logln("Capturing MSXDB catalogue for letter: " + letter);
+        }
+        else
+        {
+          logln("Capturing entire MSXDB catalogue");
+        }
+
+        logln("Fetching MSXDB from tsx.eslamejor.com...");
+        myNex.writeStr("zxdb.message.txt", "Fetching MSX catalog...");
+
+        int totalFiles = 0;
+
+        // Iterar por cada letra solicitada
+        for (int li = 0; li < searchChain.length(); li++)
+        {
+          char letterChar = searchChain.charAt(li);
+          String idxParam = String(letterChar);
+
+          // Determinar el índice para el array (0='#', 1='A'..26='Z')
+          // Para la API, '#' se envía como "0", las letras como sí mismas
+          String apiIdx = idxParam;
+          if (letterChar == '#') apiIdx = "0";
+
+          int letterIdx;
+          if (letterChar >= 'A' && letterChar <= 'Z')
+            letterIdx = 1 + (letterChar - 'A');
+          else
+            letterIdx = 0;  // '#' y '0' van al bucket numérico
+
+          String dir = (letterIdx == 0) ? "#" : String(letterChar);
+
+          if (!SD_MMC.exists("/ONLINE_MSX/" + dir))
+          {
+            SD_MMC.mkdir("/ONLINE_MSX/" + dir);
+          }
+
+          // Truncar ficheros existentes
+          File f = SD_MMC.open("/ONLINE_MSX/" + dir + "/_files.lst", FILE_WRITE);
+          if (f) f.close();
+          f = SD_MMC.open("/ONLINE_MSX/" + dir + "/_files.inf", FILE_WRITE);
+          if (f) f.close();
+
+          int lineCount = 0;
+          String buffer = "";
+          const int FLUSH_THRESHOLD = 4096;
+          int page = 0;
+          bool morePages = true;
+
+          while (morePages)
+          {
+            WiFiClientSecure secureClient;
+            secureClient.setInsecure();
+
+            HTTPClient http;
+            String apiUrl = "https://" + String(MSXDB_HOST)
+                          + "/index_back.php?page=" + String(page)
+                          + "&idx=" + apiIdx;
+
+            http.begin(secureClient, apiUrl);
+            http.setTimeout(60000);
+            http.setConnectTimeout(30000);
+            http.addHeader("User-Agent", "Mozilla/5.0");
+            http.addHeader("X-Requested-With", "XMLHttpRequest");
+            http.addHeader("Accept", "application/json");
+            http.addHeader("Referer", "https://" + String(MSXDB_HOST) + "/?idx=" + apiIdx);
+            http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+
+            int httpCode = http.GET();
+            if (httpCode == 204 || httpCode != 200)
+            {
+              // No más datos o error
+              http.end();
+              morePages = false;
+              break;
+            }
+
+            // Parsear JSON respuesta línea a línea buscando TOSEC.NAME
+            // El JSON es grande, lo procesamos por stream buscando los campos que necesitamos
+            WiFiClient* stream = http.getStreamPtr();
+            String jsonChunk = "";
+
+            // Leemos toda la respuesta (puede ser grande pero paginada a 50 items)
+            while (http.connected() || stream->available())
+            {
+              if (!stream->available()) { delay(5); continue; }
+              char c = stream->read();
+              jsonChunk += c;
+            }
+            http.end();
+
+            if (jsonChunk.length() < 10)
+            {
+              morePages = false;
+              break;
+            }
+
+            // Buscar cada ocurrencia de "TOSEC.NAME":"..." en el JSON
+            int searchFrom = 0;
+            int foundInPage = 0;
+            while (true)
+            {
+              int tosecPos = jsonChunk.indexOf("\"TOSEC.NAME\":\"", searchFrom);
+              if (tosecPos == -1) break;
+
+              int nameStart = tosecPos + 14;  // después de "TOSEC.NAME":"
+              int nameEnd = jsonChunk.indexOf("\"", nameStart);
+              if (nameEnd == -1) break;
+
+              String tosecName = jsonChunk.substring(nameStart, nameEnd);
+
+              // El fichero TSX será tosecName + ".tsx"
+              String tsxFileName = tosecName + ".tsx";
+
+              // Título limpio: extraer solo el nombre del juego (antes del primer paréntesis)
+              String title = tosecName;
+              int parenPos = title.indexOf(" (");
+              if (parenPos > 0) title = title.substring(0, parenPos);
+
+              // Añadir al buffer: lineNum|F|0|title.msxdb|tsxFileName
+              buffer += String(lineCount) + "|F|0|" + title + ".msxdb|" + tsxFileName + "\n";
+              lineCount++;
+              totalFiles++;
+              foundInPage++;
+
+              searchFrom = nameEnd + 1;
+            }
+
+            // Flush si el buffer es grande
+            if (buffer.length() > FLUSH_THRESHOLD)
+            {
+              File lst = SD_MMC.open("/ONLINE_MSX/" + dir + "/_files.lst", FILE_APPEND);
+              if (lst)
+              {
+                lst.print(buffer);
+                lst.flush();
+                lst.close();
+              }
+              buffer = "";
+            }
+
+            // Si encontramos menos de 50 items, no hay más páginas
+            if (foundInPage < 50)
+            {
+              morePages = false;
+            }
+            else
+            {
+              page++;
+            }
+
+            // Progreso
+            myNex.writeStr("zxdb.message.txt", "Found " + String(totalFiles) + " MSX games...");
+          }
+
+          // Flush buffer restante
+          if (buffer.length() > 0)
+          {
+            File lst = SD_MMC.open("/ONLINE_MSX/" + dir + "/_files.lst", FILE_APPEND);
+            if (lst)
+            {
+              lst.print(buffer);
+              lst.flush();
+              lst.close();
+            }
+          }
+
+          // Generar _files.inf
+          File inf = SD_MMC.open("/ONLINE_MSX/" + dir + "/_files.inf", FILE_WRITE);
+          if (inf)
+          {
+            inf.println("PATH=/ONLINE_MSX/" + dir + "/");
+            inf.print("CFIL=");
+            inf.println(lineCount);
+            inf.println("CDIR=0");
+            inf.flush();
+            inf.close();
+          }
+        }
+
+        logln("MSXDB: " + String(totalFiles) + " ficheros catalogados");
+        myNex.writeStr("zxdb.message.txt", "Done: " + String(totalFiles) + " MSX games");
         myNex.writeNum("zxdb.j0.val", 100);
     }
 }

--- a/src/globales.h
+++ b/src/globales.h
@@ -831,6 +831,7 @@ String SPOTIFY_CLIENT_SECRET = "";
 //
 bool QUICK_BOOT = false;
 bool DOWNLOADING_ZXDB = false;
+bool DOWNLOADING_CPCDB = false;
 bool BEEP = false;
 
 // Declaraciones de metodos
@@ -2228,5 +2229,320 @@ void updateZXDB(String letter = "0")
           myNex.writeStr("zxdb.message.txt", "Capturing finished");
           myNex.writeNum("zxdb.j0.val", 100);
         }
+    }
+}
+
+// =====================================================================
+// CPCDB - Descarga de juegos Amstrad CPC desde Archive.org
+// Colección: amstrad-cpc-cdt-collection (CDTs individuales dentro de ZIP)
+// =====================================================================
+
+// URL base para listar el contenido del ZIP en Archive.org
+const char* CPCDB_ARCHIVE_ID = "amstrad-cpc-cdt-collection";
+const char* CPCDB_ZIP_NAME   = "AmstradCPC-CDT_Collection.zip";
+
+// Descarga un fichero CDT individual desde Archive.org
+// fileName : nombre exacto del CDT dentro del ZIP (e.g. "Ace (E).cdt")
+// title    : nombre del juego para crear el subdirectorio en /DOWNLOAD/
+void downloadFromCPCDB(String fileName, String title)
+{
+  DOWNLOADING_CPCDB = true;
+  TYPE_FILE_LOAD = "CPCDB";
+
+  LAST_MESSAGE = "Downloading: " + title;
+  myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+
+  if (!WIFI_CONNECTED || !WIFI_ENABLE)
+  {
+    logln("WiFi no disponible para descarga CPCDB");
+    myNex.writeStr("tape.g0.txt", "No WiFi");
+    DOWNLOADING_CPCDB = false;
+    return;
+  }
+
+  // Sanitizar el título para nombre de directorio FAT32
+  String safeTitle = title;
+  safeTitle.replace("/",  "-");
+  safeTitle.replace("\\", "-");
+  safeTitle.replace(":",  "-");
+  safeTitle.replace("*",  "-");
+  safeTitle.replace("?",  "-");
+  safeTitle.replace("\"", "-");
+  safeTitle.replace("<",  "-");
+  safeTitle.replace(">",  "-");
+  safeTitle.replace("|",  "-");
+
+  String destDir = "/DOWNLOAD_CPC/" + safeTitle;
+
+  if (!SD_MMC.exists("/DOWNLOAD_CPC")) SD_MMC.mkdir("/DOWNLOAD_CPC");
+  if (!SD_MMC.exists(destDir))
+  {
+    if (!SD_MMC.mkdir(destDir))
+    {
+      logln("Error al crear directorio: " + destDir);
+      myNex.writeStr("tape.g0.txt", "Error creating dir");
+      DOWNLOADING_CPCDB = false;
+      return;
+    }
+  }
+
+  // Construir URL de descarga directa del CDT dentro del ZIP de Archive.org
+  // Los ficheros están dentro del subdirectorio CDT/ en el ZIP
+  String encodedFileName = fileName;
+  encodedFileName.replace(" ", "%20");
+  encodedFileName.replace("(", "%28");
+  encodedFileName.replace(")", "%29");
+  encodedFileName.replace("'", "%27");
+  encodedFileName.replace("&", "%26");
+  encodedFileName.replace(",", "%2C");
+
+  String downloadUrl = "https://archive.org/download/"
+                       + String(CPCDB_ARCHIVE_ID) + "/"
+                       + String(CPCDB_ZIP_NAME) + "/CDT/"
+                       + encodedFileName;
+
+  logln("Descargando CDT: " + downloadUrl);
+  myNex.writeStr("tape.g0.txt", "Downloading: " + fileName);
+
+  String localPath = destDir + "/" + fileName;
+
+  // Descarga específica para Archive.org: usamos writeToStream para que
+  // HTTPClient decodifique chunked transfer-encoding correctamente
+  {
+    WiFiClientSecure secureClient;
+    secureClient.setInsecure();
+
+    HTTPClient http;
+    http.begin(secureClient, downloadUrl);
+    http.setTimeout(60000);
+    http.setConnectTimeout(30000);
+    http.addHeader("User-Agent", "PowaDCR/" + String(VERSION));
+    http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+
+    int httpCode = http.GET();
+    if (httpCode == HTTP_CODE_OK)
+    {
+      File file = SD_MMC.open(localPath.c_str(), FILE_WRITE);
+      if (file)
+      {
+        int written = http.writeToStream(&file);
+        file.flush();
+        file.close();
+        logln("Descargados " + String(written) + " bytes -> " + localPath);
+        LAST_MESSAGE = "Download done. See /DOWNLOAD_CPC";
+        myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+      }
+      else
+      {
+        logln("No se pudo crear fichero: " + localPath);
+        LAST_MESSAGE = "Error creating file";
+        myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+      }
+    }
+    else
+    {
+      logln("Error HTTP " + String(httpCode) + " descargando: " + downloadUrl);
+      LAST_MESSAGE = "Download error " + String(httpCode);
+      myNex.writeStr("tape.g0.txt", LAST_MESSAGE);
+    }
+    http.end();
+  }
+
+  DOWNLOADING_CPCDB = false;
+}
+
+// Descarga y parsea el listado de CDTs de Archive.org para generar
+// el catálogo /ONLINE_CPC/{letra}/_files.lst
+// El listado se obtiene del HTML de view_archive.php
+void updateCPCDB(String letter = "0")
+{
+    String searchChain = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    if (WIFI_CONNECTED && WIFI_ENABLE)
+    {
+        myNex.writeNum("zxdb.j0.val", 0);
+
+        if (letter != "0")
+        {
+          searchChain = letter;
+          logln("Capturing CPCDB catalogue for letter: " + letter);
+        }
+        else
+        {
+          logln("Capturing entire CPCDB catalogue");
+        }
+
+        // Primero descargamos la lista completa de ficheros del ZIP
+        // usando la API de metadata de Archive.org
+        logln("Fetching CPCDB file list from Archive.org...");
+        myNex.writeStr("zxdb.message.txt", "Fetching CPC catalog...");
+
+        WiFiClientSecure secureClient;
+        secureClient.setInsecure();
+
+        HTTPClient http;
+        // Usamos view_archive para obtener el listado HTML del ZIP
+        String listUrl = "https://archive.org/download/"
+                         + String(CPCDB_ARCHIVE_ID) + "/"
+                         + String(CPCDB_ZIP_NAME) + "/";
+
+        http.begin(secureClient, listUrl);
+        http.setTimeout(60000);
+        http.setConnectTimeout(30000);
+        http.addHeader("User-Agent", "PowaDCR/" + String(VERSION));
+        http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+
+        int httpCode = http.GET();
+        if (httpCode != 200)
+        {
+          logln("Error HTTP al obtener listado CPCDB: " + String(httpCode));
+          myNex.writeStr("zxdb.message.txt", "Error " + String(httpCode));
+          http.end();
+          return;
+        }
+
+        // Procesamos el HTML línea a línea buscando enlaces a .cdt
+        // Formato esperado en el HTML: <a href="...">NombreJuego.cdt</a>
+        WiFiClient* stream = http.getStreamPtr();
+
+        // Estructuras temporales: arrays por letra
+        // Para no usar demasiada RAM, procesamos línea a línea y escribimos directamente
+
+        // Preparar directorios y ficheros por letra
+        for (int i = 0; i < searchChain.length(); i++)
+        {
+          char ch = searchChain.charAt(i);
+          String dir = String(ch);
+
+          if (!SD_MMC.exists("/ONLINE_CPC/" + dir))
+          {
+            SD_MMC.mkdir("/ONLINE_CPC/" + dir);
+          }
+
+          // Truncar _files.lst y _files.inf
+          File f = SD_MMC.open("/ONLINE_CPC/" + dir + "/_files.lst", FILE_WRITE);
+          if (f) f.close();
+          f = SD_MMC.open("/ONLINE_CPC/" + dir + "/_files.inf", FILE_WRITE);
+          if (f) f.close();
+        }
+
+        // Contadores por letra (A-Z + #)
+        int lineCount[27] = {0};  // 0='#', 1='A', ..., 26='Z'
+        int totalFiles = 0;
+
+        // Buffer para acumular líneas por letra antes de escribir
+        String buffers[27];
+        const int FLUSH_THRESHOLD = 4096;  // Flush cada 4KB aprox
+
+        // Leemos el stream HTML línea a línea
+        // Formato real: <tr><td><a href="...">CDT/NombreJuego.cdt</a><td>...
+        String htmlLine = "";
+        while (http.connected() || stream->available())
+        {
+          if (!stream->available()) { delay(10); continue; }
+
+          htmlLine = stream->readStringUntil('\n');
+
+          // Buscamos filas con enlaces a .cdt
+          if (htmlLine.indexOf(".cdt</a>") == -1 && htmlLine.indexOf(".cdt<") == -1) continue;
+
+          // Extraer el texto visible del enlace: lo que hay entre > y </a>
+          // Formato: <a href="...">CDT/NombreJuego.cdt</a>
+          int aClose = htmlLine.indexOf("</a>");
+          if (aClose == -1) continue;
+          // Buscamos el > justo antes del texto del enlace
+          int textStart = htmlLine.lastIndexOf('>', aClose - 1);
+          if (textStart == -1) continue;
+          textStart++; // saltar el '>'
+
+          String cdtPath = htmlLine.substring(textStart, aClose);
+          cdtPath.trim();
+
+          if (!cdtPath.endsWith(".cdt")) continue;
+
+          // Quitar el prefijo "CDT/" si existe
+          String cdtName = cdtPath;
+          if (cdtName.startsWith("CDT/")) cdtName = cdtName.substring(4);
+
+          // Determinar la letra inicial
+          char firstChar = cdtName.charAt(0);
+          if (firstChar >= 'a' && firstChar <= 'z') firstChar -= 32;  // mayúscula
+
+          int letterIdx;
+          if (firstChar >= 'A' && firstChar <= 'Z')
+            letterIdx = 1 + (firstChar - 'A');
+          else
+            letterIdx = 0;  // '#' para números y símbolos
+
+          // Verificar si esta letra está en searchChain
+          char letterChar = (letterIdx == 0) ? '#' : ('A' + letterIdx - 1);
+          if (searchChain.indexOf(letterChar) == -1) continue;
+
+          // Generar título limpio (sin extensión .cdt)
+          String title = cdtName.substring(0, cdtName.length() - 4);
+
+          // Añadir al buffer: lineNum|F|0|title.cpcdb|cdtFileName
+          buffers[letterIdx] += String(lineCount[letterIdx]) + "|F|0|" + title + ".cpcdb|" + cdtName + "\n";
+          lineCount[letterIdx]++;
+          totalFiles++;
+
+          // Flush si el buffer es grande
+          if (buffers[letterIdx].length() > FLUSH_THRESHOLD)
+          {
+            String dir = (letterIdx == 0) ? "#" : String(letterChar);
+            File lst = SD_MMC.open("/ONLINE_CPC/" + dir + "/_files.lst", FILE_APPEND);
+            if (lst)
+            {
+              lst.print(buffers[letterIdx]);
+              lst.flush();
+              lst.close();
+            }
+            buffers[letterIdx] = "";
+          }
+
+          // Progreso
+          if (totalFiles % 100 == 0)
+          {
+            myNex.writeStr("zxdb.message.txt", "Found " + String(totalFiles) + " CPC games...");
+          }
+        }
+
+        http.end();
+
+        // Flush de buffers restantes y generar _files.inf
+        for (int i = 0; i < 27; i++)
+        {
+          char letterChar = (i == 0) ? '#' : ('A' + i - 1);
+          if (searchChain.indexOf(letterChar) == -1) continue;
+
+          String dir = String(letterChar);
+
+          if (buffers[i].length() > 0)
+          {
+            File lst = SD_MMC.open("/ONLINE_CPC/" + dir + "/_files.lst", FILE_APPEND);
+            if (lst)
+            {
+              lst.print(buffers[i]);
+              lst.flush();
+              lst.close();
+            }
+          }
+
+          // Generar _files.inf
+          File inf = SD_MMC.open("/ONLINE_CPC/" + dir + "/_files.inf", FILE_WRITE);
+          if (inf)
+          {
+            inf.println("PATH=/ONLINE_CPC/" + dir + "/");
+            inf.print("CFIL=");
+            inf.println(lineCount[i]);
+            inf.println("CDIR=0");
+            inf.flush();
+            inf.close();
+          }
+        }
+
+        logln("CPCDB: " + String(totalFiles) + " ficheros catalogados");
+        myNex.writeStr("zxdb.message.txt", "Done: " + String(totalFiles) + " CPC games");
+        myNex.writeNum("zxdb.j0.val", 100);
     }
 }

--- a/src/powadcr.cpp
+++ b/src/powadcr.cpp
@@ -4251,6 +4251,11 @@ void playingFile() {
     LAST_MESSAGE = "Wait for scanning end.";
     //ZXDBPlayer();
     logln("Finish ZXDB playing file");
+  } else if (TYPE_FILE_LOAD == "CPCDB") {
+    logln("Type file load: " + TYPE_FILE_LOAD);
+    // Fichero virtual CPCDB - la descarga se gestiona desde HMI
+    LAST_MESSAGE = "Wait for scanning end.";
+    logln("Finish CPCDB playing file");
   } else {
     logAlert("Unknown type_file_load");
   }
@@ -4558,6 +4563,10 @@ void loadingFile(char *file_ch) {
       logln("ZXDB file to load: " + PATH_FILE_TO_LOAD);
       FILE_PREPARED = true;
       TYPE_FILE_LOAD = "ZXDB";
+    } else if (PATH_FILE_TO_LOAD.indexOf(".CPCDB", PATH_FILE_TO_LOAD.length() - 6) != -1) {
+      logln("CPCDB file to load: " + PATH_FILE_TO_LOAD);
+      FILE_PREPARED = true;
+      TYPE_FILE_LOAD = "CPCDB";
     }
   } else {
     #ifdef DEBUGMODE
@@ -5717,7 +5726,7 @@ void tapeControl() {
             FILE_PREPARED = false;
           }
 
-          if (TYPE_FILE_LOAD != "ZXDB")
+          if (TYPE_FILE_LOAD != "ZXDB" && TYPE_FILE_LOAD != "CPCDB")
           {
             LAST_MESSAGE = "No file inside the tape";
           }
@@ -8162,18 +8171,52 @@ void Task0code(void *pvParameters) {
     hmi.readUART();
     //   startTime5 = millis();
     // }
+
+    // Mini consola de debug por Serial (UART0) para pruebas
+    if (Serial.available())
+    {
+      String dbgCmd = Serial.readStringUntil('\n');
+      dbgCmd.trim();
+      if (dbgCmd == "cpcdb_update")
+      {
+        logln("[DBG] Updating entire CPCDB catalogue...");
+        updateCPCDB("0");
+      }
+      else if (dbgCmd.startsWith("cpcdb_update "))
+      {
+        String letter = dbgCmd.substring(13);
+        letter.trim();
+        logln("[DBG] Updating CPCDB for letter: " + letter);
+        updateCPCDB(letter);
+      }
+      else if (dbgCmd.startsWith("cpcdb_download "))
+      {
+        // Ejemplo: cpcdb_download Ace (E).cdt
+        String cdtName = dbgCmd.substring(15);
+        cdtName.trim();
+        String title = cdtName.substring(0, cdtName.length() - 4);
+        logln("[DBG] Downloading CPC CDT: " + cdtName);
+        downloadFromCPCDB(cdtName, title);
+      }
+      else if (dbgCmd == "zxdb_update")
+      {
+        logln("[DBG] Updating entire ZXDB catalogue...");
+        updateZXDB("0");
+      }
+    }
+
     delay(25);
 
     // Control del FTP
     #ifdef FTP_SERVER_ENABLE
-      if (!IRADIO_EN && WIFI_ENABLE && WIFI_CONNECTED && !FLAC_IS_PLAYING && !DOWNLOADING_ZXDB) 
+      if (!IRADIO_EN && WIFI_ENABLE && WIFI_CONNECTED && !FLAC_IS_PLAYING && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB)
       {
         ftpSrv.handleFTP();
       }
     #endif
 
     #ifdef WEB_SERVER_ENABLE
-    if (!FLAC_IS_PLAYING && WIFI_ENABLE && WIFI_CONNECTED && !DOWNLOADING_ZXDB)
+    if (!FLAC_IS_PLAYING && WIFI_ENABLE && WIFI_CONNECTED && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB)
     {
       WiFiClient client = server.available();
       if (client) 
@@ -8387,7 +8430,7 @@ void Task0code(void *pvParameters) {
       // Hacemos poll de la botonera
       if (millis() - startTimeKey > timeKeyPoll)
       {
-        if (!FILE_BROWSER_OPEN) //(CURRENT_PAGE <= 1 || CURRENT_PAGE == 99) &&
+        if (!FILE_BROWSER_OPEN && MCP23017_AVAILABLE) //(CURRENT_PAGE <= 1 || CURRENT_PAGE == 99) &&
         {
             buttonsControl();
         }          
@@ -8901,6 +8944,23 @@ void prepareCardStructure() {
     if (!QUICK_BOOT) delay(750);
   }
 
+  // Creamos el directorio /ONLINE_CPC para catálogo Amstrad CPC
+  fDir = "/ONLINE_CPC";
+
+  if (createSpecialDirectory(fDir)) {
+    hmi.writeString("statusLCD.txt=\"Creating ONLINE_CPC directory\"");
+    hmi.reloadCustomDir("/");
+    if (!QUICK_BOOT) delay(750);
+  }
+
+  // Creamos el directorio /DOWNLOAD_CPC para descargas Amstrad CPC
+  fDir = "/DOWNLOAD_CPC";
+
+  if (createSpecialDirectory(fDir)) {
+    hmi.writeString("statusLCD.txt=\"Creating DOWNLOAD_CPC directory\"");
+    hmi.reloadCustomDir("/");
+    if (!QUICK_BOOT) delay(750);
+  }
 
   // Creamos el directorio /fav
   fDir = "/FAV";

--- a/src/powadcr.cpp
+++ b/src/powadcr.cpp
@@ -4256,6 +4256,11 @@ void playingFile() {
     // Fichero virtual CPCDB - la descarga se gestiona desde HMI
     LAST_MESSAGE = "Wait for scanning end.";
     logln("Finish CPCDB playing file");
+  } else if (TYPE_FILE_LOAD == "MSXDB") {
+    logln("Type file load: " + TYPE_FILE_LOAD);
+    // Fichero virtual MSXDB - la descarga se gestiona desde HMI
+    LAST_MESSAGE = "Wait for scanning end.";
+    logln("Finish MSXDB playing file");
   } else {
     logAlert("Unknown type_file_load");
   }
@@ -4567,6 +4572,10 @@ void loadingFile(char *file_ch) {
       logln("CPCDB file to load: " + PATH_FILE_TO_LOAD);
       FILE_PREPARED = true;
       TYPE_FILE_LOAD = "CPCDB";
+    } else if (PATH_FILE_TO_LOAD.indexOf(".MSXDB", PATH_FILE_TO_LOAD.length() - 6) != -1) {
+      logln("MSXDB file to load: " + PATH_FILE_TO_LOAD);
+      FILE_PREPARED = true;
+      TYPE_FILE_LOAD = "MSXDB";
     }
   } else {
     #ifdef DEBUGMODE
@@ -5726,7 +5735,7 @@ void tapeControl() {
             FILE_PREPARED = false;
           }
 
-          if (TYPE_FILE_LOAD != "ZXDB" && TYPE_FILE_LOAD != "CPCDB")
+          if (TYPE_FILE_LOAD != "ZXDB" && TYPE_FILE_LOAD != "CPCDB" && TYPE_FILE_LOAD != "MSXDB")
           {
             LAST_MESSAGE = "No file inside the tape";
           }
@@ -8198,6 +8207,29 @@ void Task0code(void *pvParameters) {
         logln("[DBG] Downloading CPC CDT: " + cdtName);
         downloadFromCPCDB(cdtName, title);
       }
+      else if (dbgCmd == "msxdb_update")
+      {
+        logln("[DBG] Updating entire MSXDB catalogue...");
+        updateMSXDB("0");
+      }
+      else if (dbgCmd.startsWith("msxdb_update "))
+      {
+        String letter = dbgCmd.substring(13);
+        letter.trim();
+        logln("[DBG] Updating MSXDB for letter: " + letter);
+        updateMSXDB(letter);
+      }
+      else if (dbgCmd.startsWith("msxdb_download "))
+      {
+        // Ejemplo: msxdb_download Zakil Wood (1985)(Mr Micro)(ES)[!][BLOAD'CAS-',R][v0.8.5b].tsx
+        String tsxName = dbgCmd.substring(15);
+        tsxName.trim();
+        String title = tsxName;
+        int parenPos = title.indexOf(" (");
+        if (parenPos > 0) title = title.substring(0, parenPos);
+        logln("[DBG] Downloading MSX TSX: " + tsxName);
+        downloadFromMSXDB(tsxName, title);
+      }
       else if (dbgCmd == "zxdb_update")
       {
         logln("[DBG] Updating entire ZXDB catalogue...");
@@ -8209,14 +8241,14 @@ void Task0code(void *pvParameters) {
 
     // Control del FTP
     #ifdef FTP_SERVER_ENABLE
-      if (!IRADIO_EN && WIFI_ENABLE && WIFI_CONNECTED && !FLAC_IS_PLAYING && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB)
+      if (!IRADIO_EN && WIFI_ENABLE && WIFI_CONNECTED && !FLAC_IS_PLAYING && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB && !DOWNLOADING_MSXDB)
       {
         ftpSrv.handleFTP();
       }
     #endif
 
     #ifdef WEB_SERVER_ENABLE
-    if (!FLAC_IS_PLAYING && WIFI_ENABLE && WIFI_CONNECTED && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB)
+    if (!FLAC_IS_PLAYING && WIFI_ENABLE && WIFI_CONNECTED && !DOWNLOADING_ZXDB && !DOWNLOADING_CPCDB && !DOWNLOADING_MSXDB)
     {
       WiFiClient client = server.available();
       if (client) 
@@ -9125,6 +9157,14 @@ void setupSDCard() {
     logln("SD Card mounted");
     hmi.writeString("statusLCD.txt=\"SD_MMC available\"");
     delay(125);
+
+    // Crear carpetas base para catálogos online y descargas
+    if (!SD_MMC.exists("/ONLINE"))      SD_MMC.mkdir("/ONLINE");
+    if (!SD_MMC.exists("/ONLINE_CPC"))  SD_MMC.mkdir("/ONLINE_CPC");
+    if (!SD_MMC.exists("/ONLINE_MSX"))  SD_MMC.mkdir("/ONLINE_MSX");
+    if (!SD_MMC.exists("/DOWNLOAD"))    SD_MMC.mkdir("/DOWNLOAD");
+    if (!SD_MMC.exists("/DOWNLOAD_CPC")) SD_MMC.mkdir("/DOWNLOAD_CPC");
+    if (!SD_MMC.exists("/DOWNLOAD_MSX")) SD_MMC.mkdir("/DOWNLOAD_MSX");
   }
 
   if (psramInit()) {
@@ -9525,7 +9565,7 @@ void setup() {
   //
   // -------------------------------------------------------------------------
   if (WIFI_CONNECTED && WIFI_ENABLE)
-  {  
+  {
     setupNTP();
   }
   // Connect to Spotify


### PR DESCRIPTION
## Summary

- Add MSX tape dump (TSX) download from [tsx.eslamejor.com](https://tsx.eslamejor.com/) — a curated archive of **2300+ MSX tapes** with 100% accuracy, TOSEC naming convention
- TSX format is natively supported by the existing TZX processor, so downloaded files play directly
- Catalog built via JSON API, individual files downloaded from /tsx-files/
- Follows the same pattern as ZXDB (ZX Spectrum) and CPCDB (Amstrad CPC) online downloads

## Changes

- **globales.h**: downloadFromMSXDB(), updateMSXDB(), DOWNLOADING_MSXDB flag
- **HMI.h**: .msxdb virtual extension, CMSX command, MSXD= command, ONLINE_MSX guards
- **powadcr.cpp**: MSXDB file type handling, download guards, debug serial commands, unified folder creation at boot

## Test plan

- [x] Firmware compiles successfully
- [x] Test download verified: Zakil Wood TSX — 63750 bytes
- [ ] Test msxdb_update catalog generation
- [ ] HMI button for CMSX command (pending)

Generated with [Claude Code](https://claude.com/claude-code)